### PR TITLE
Multi region tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ echo "export PRX_SSH_KEY=~/.ssh/id_ed25519_prx_developer" >> ~/.bash_profile
 echo "export PRX_AWS_PROFILE=prx-default" >> ~/.bash_profile
 ```
 
+# Scripts
+
+## awssh
+
+The `awssh` command allows you to ssh into a running EC2 instance or ECS task.
+You can get a shell on the host EC2, a shell inside the running Docker container,
+or even attach to a Rails/Elixir/etc console.
+
+## awstunnel
+
+Our production databases are all in a private VPC, inaccessible from the public
+internet. To gain access locally, use the `awstunnel` script which tunnels some
+local high port numbers through our jump servers, to the staging/production db
+servers.
+
 # Contribute
 
 After you've made your changes and committed them to the main branch, create a new release in GitHub, with a new version tag (in the format `v1.2.3`). Once the release has been created, a GitHub action will automatically update the formula file to match the newly-released version and update the SHA 256 hash.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ brew tap prx/dev-tools
 brew install prx-dev-tools
 ```
 
+# Configuration
+
+You can optionally configure these scripts to use certain AWS profiles and dev tools:
+
+```sh
+echo "export PRX_SSH_KEY=~/.ssh/id_ed25519_prx_developer" >> ~/.bash_profile
+echo "export PRX_AWS_PROFILE=prx-default" >> ~/.bash_profile
+```
+
 # Contribute
 
 After you've made your changes and committed them to the main branch, create a new release in GitHub, with a new version tag (in the format `v1.2.3`). Once the release has been created, a GitHub action will automatically update the formula file to match the newly-released version and update the SHA 256 hash.

--- a/bin/awssh
+++ b/bin/awssh
@@ -1,20 +1,19 @@
 #!/bin/bash
-ECS_KEY="id_ed25519_prx_developer"
-PROD_CLUSTER="infrastructure-cd-root-production-SharedEcsClusterStack-11IXC7OZI6I4U-EcsCluster-AJ4yJsOu3QDc"
-STAG_CLUSTER="infrastructure-cd-root-staging-SharedEcsClusterStack-1U7T895ADTHR9-EcsCluster-3TUHESV7htXa"
-
-export AWS_PROFILE=prx-legacy
-export AWS_DEFAULT_REGION=us-east-1
+PRX_DEFAULT_REGION=us-east-1
+SSH_USER=ec2-user
+SSH_OPTS="-o StrictHostKeyChecking=accept-new"
+[[ ! -z $PRX_SSH_KEY ]] && SSH_OPTS="$SSH_OPTS -i $PRX_SSH_KEY"
+[[ ! -z $PRX_AWS_PROFILE ]] && export AWS_PROFILE="$PRX_AWS_PROFILE"
 
 function usage() {
   echo "Usage:"
-  echo "  awssh <ec2-instance-id>"
-  echo "  awssh [stag|prod] <service>"
-  echo "  awssh [stag|prod] <service> <command>"
+  echo "  awssh <ec2-instance-id> --region [aws-region]"
+  echo "  awssh <stag|prod> <service> --region [aws-region]"
+  echo "  awssh <stag|prod> <service> <command> --region [aws-region]"
   echo ""
   echo "Examples:"
   echo "  awssh i-1234567890"
-  echo "  awssh stag cms"
+  echo "  awssh stag cms --region us-west-2"
   echo "  awssh stag cms console"
   echo "  awssh stag cms host"
   echo ""
@@ -31,24 +30,22 @@ function ssh_to_task() {
   RUN_CMD="$3"
 
   # match a service name
-  SERVICES=`aws ecs list-services --cluster $CLUSTER --output json 2> /dev/null | jq -r ".serviceArns[]"`
-  if [[ -n "$MATCH_NAME" ]]; then
-    SERVICES=`printf "$SERVICES" | grep -i "$MATCH_NAME"`
-  fi
-  if [[ -z "$SERVICES" ]]; then
-    echo "unable to find service match: $MATCH_NAME"
+  JQ_SELECT="map(select(ascii_downcase | contains(\"$MATCH_NAME\")))"
+  JQ_SORT="sort_by(ascii_downcase | contains(\"worker\"))"
+  SERVICE=`aws ecs list-services --cluster $CLUSTER | jq -r ".serviceArns | $JQ_SELECT | $JQ_SORT | last"`
+  if [[ "$SERVICE" == "null" ]]; then
+    echo "Unable to find service match: $MATCH_NAME"
     exit 1
   fi
-  SERVICE=`printf $SERVICES | head -1`
 
   # find instance id with this service name running on it
-  ARN=`aws ecs list-tasks --cluster $CLUSTER --service-name $SERVICE --output json 2> /dev/null | jq -r ".taskArns[0]"`
+  ARN=`aws ecs list-tasks --cluster $CLUSTER --service-name $SERVICE | jq -r ".taskArns[0]"`
   if [[ "$ARN" == "" || "$ARN" == "null" ]]; then
-    echo "no running tasks for service $SERVICE"
+    echo "No running tasks for service $SERVICE"
     exit 1
   fi
-  CONTAINER=`aws ecs describe-tasks --cluster $CLUSTER --tasks $ARN --output json | jq -r ".tasks[0].containerInstanceArn"`
-  ID=`aws ecs describe-container-instances --cluster $CLUSTER --container-instances $CONTAINER --output json | jq -r ".containerInstances[0].ec2InstanceId"`
+  CONTAINER=`aws ecs describe-tasks --cluster $CLUSTER --tasks $ARN | jq -r ".tasks[0].containerInstanceArn"`
+  ID=`aws ecs describe-container-instances --cluster $CLUSTER --container-instances $CONTAINER | jq -r ".containerInstances[0].ec2InstanceId"`
 
   ssh_to_ec2 $ID $MATCH_NAME $RUN_CMD
 }
@@ -59,18 +56,19 @@ function ssh_to_ec2() {
   MATCH_NAME="$2"
   RUN_CMD="$3"
 
-  IP=`aws ec2 describe-instances --instance-ids $ID --output json | jq -r ".Reservations[0].Instances[0].PublicIpAddress"`
+  # TODO: ssh through jump server to private IP instead
+  IP=`aws ec2 describe-instances --instance-ids $ID | jq -r ".Reservations[0].Instances[0].PublicIpAddress"`
   if [[ "$IP" == "" ]]; then
     echo "instance $ID not found"
     exit 1
   fi
 
   if [[ -z "$MATCH_NAME" || "$RUN_CMD" == "host" ]]; then
-    ssh -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile /dev/null" -i ~/.ssh/$ECS_KEY ec2-user@${IP}
+    ssh -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile /dev/null" $SSH_USER@${IP}
   else
     REAL_CMD="/bin/ash"
-    if [[ "$MATCH_NAME" == "sphinx" || "$MATCH_NAME" == "networks" || "$MATCH_NAME" == "exchange" || "$MATCH_NAME" == "thecount" ]]; then
-      REAL_CMD="/bin/bash"
+    if [[ "$MATCH_NAME" == "sphinx" || "$MATCH_NAME" == "networks" || "$MATCH_NAME" == "exchange" ]]; then
+      REAL_CMD="bin/bash"
     fi
     if [[ -n "$RUN_CMD" ]]; then
       REAL_CMD="./bin/application $RUN_CMD"
@@ -80,17 +78,43 @@ function ssh_to_ec2() {
     rows=$(tput lines)
 
     CMD="docker exec -it \$(docker ps --filter name=$MATCH_NAME --quiet --latest) /bin/sh -c \"stty cols $cols rows $rows && $REAL_CMD\""
-    ssh -t -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile /dev/null" -i ~/.ssh/$ECS_KEY ec2-user@${IP} "$CMD"
+    ssh -t -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile /dev/null" $SSH_USER@${IP} "$CMD"
   fi
 }
+
+# args
+ENV="$1"
+if [[ $2 == "--region" ]]; then
+  export AWS_REGION=$3
+elif [[ $3 == "--region" ]]; then
+  export AWS_REGION=$4
+elif [[ $4 == "--region" ]]; then
+  export AWS_REGION=$5
+else
+  export AWS_REGION=$PRX_DEFAULT_REGION
+fi
+export AWS_DEFAULT_OUTPUT="json"
 
 # run!
 if [[ $1 == i-* ]]; then
   ssh_to_ec2 $1
-elif [[ "$1" == "prod" ]]; then
-  ssh_to_task $PROD_CLUSTER $2 $3
+elif [[ "$1" == "prod" || "$1" == "stag" ]]; then
+  JUMP_SUFFIX="$AWS_REGION.prx.tech"
+  [[ "$1" == "prod" ]] && JUMP_HOST="jump.$JUMP_SUFFIX" || JUMP_HOST="jump.staging.$JUMP_SUFFIX"
+  NAME=`ssh $SSH_USER@$JUMP_HOST $SSH_OPTS 'echo $PRX_ECS_CLUSTER_NAME'`
+  if [[ $? != 0 ]]; then
+    echo "Error: $NAME"
+    # TODO: removing stale known_hosts (ssh-keygen -R jump.prx.tech)
+    exit 1
+  else
+    ssh_to_task $NAME $2 $3
+  fi
+
 elif [[ "$1" == "stag" ]]; then
-  ssh_to_task $STAG_CLUSTER $2 $3
+  NAME=$(ecs_cluster_name $1 $AWS_DEFAULT_REGION)
+  echo $NAME
+  # exit
+  ssh_to_task $NAME $2 $3
 else
   usage
 fi

--- a/bin/awstunnel
+++ b/bin/awstunnel
@@ -1,0 +1,64 @@
+#!/bin/bash
+PRX_DEFAULT_REGION=us-east-1
+SSH_USER=ec2-user
+SSH_OPTS="-o StrictHostKeyChecking=accept-new"
+[[ ! -z $PRX_SSH_KEY ]] && SSH_OPTS="$SSH_OPTS -i $PRX_SSH_KEY"
+[[ ! -z $PRX_AWS_PROFILE ]] && export AWS_PROFILE="$PRX_AWS_PROFILE"
+
+# args
+ENV="$1"
+REGION=$([[ $2 == "--region" ]] && $3 || $PRX_DEFAULT_REGION)
+if [[ ($ENV != "prod" && $ENV != "stag") || -z $REGION ]]; then
+  echo "Usage: awstunnel <stag|prod> --region [aws-region]"
+  exit 1
+fi
+
+# alias env to jump hostname
+if [[ $ENV == "prod" ]]; then
+  JUMP_HOST="jump.${REGION}.prx.tech"
+else
+  JUMP_HOST="jump.staging.$REGION.prx.tech"
+fi
+echo "Connecting to $JUMP_HOST..."
+
+# get env, and check for host key failure (jump servers can cycle out)
+OUT=`ssh $SSH_USER@$JUMP_HOST $SSH_OPTS 'printenv | grep ^PRX_'`
+if [[ $? != 0 ]]; then
+  echo "Error: $OUT"
+  # TODO: removing stale known_hosts (ssh-keygen -R jump.prx.tech)
+  exit 1
+else
+  export xargs $OUT
+fi
+
+# TODO: do we care to vary local ports by env/region?
+if [[ $ENV == "prod" ]]; then
+  MYSQL_LOCAL_PORT=3307
+  POSTGRES_LOCAL_PORT=5433
+  CASTLE_LOCAL_PORT=5434
+  REDIS_LOCAL_PORT=6380
+else
+  MYSQL_LOCAL_PORT=3309
+  POSTGRES_LOCAL_PORT=5435
+  CASTLE_LOCAL_PORT=5436
+  REDIS_LOCAL_PORT=6382
+fi
+
+# print configuration
+echo ""
+echo "+------+----------------------------+"
+echo "| Port | Tunnel Destination         |"
+echo "+------+----------------------------+"
+[[ ! -z "$PRX_SHARED_MYSQL_HOST" ]] && echo "| $MYSQL_LOCAL_PORT | $(printf %-26s "Shared Mysql $PRX_ENVIRONMENT") |"
+[[ ! -z "$PRX_SHARED_POSTGRES_HOST" ]] && echo "| $POSTGRES_LOCAL_PORT | $(printf %-26s "Shared Postgres $PRX_ENVIRONMENT") |"
+[[ ! -z "$PRX_CASTLE_POSTGRES_HOST" ]] && echo "| $CASTLE_LOCAL_PORT | $(printf %-26s "Castle Postgres $PRX_ENVIRONMENT") |"
+[[ ! -z "$PRX_SHARED_REDIS_HOST" ]] && echo "| $REDIS_LOCAL_PORT | $(printf %-26s "Shared Redis $PRX_ENVIRONMENT") |"
+echo "+------+----------------------------+"
+
+# time for tunneling
+ssh $SSH_USER@$JUMP_HOST -N \
+  $( [[ ! -z "$PRX_SHARED_MYSQL_HOST" ]] && printf %s "-L $MYSQL_LOCAL_PORT:$PRX_SHARED_MYSQL_HOST:$PRX_SHARED_MYSQL_PORT" ) \
+  $( [[ ! -z "$PRX_SHARED_POSTGRES_HOST" ]] && printf %s "-L $POSTGRES_LOCAL_PORT:$PRX_SHARED_POSTGRES_HOST:$PRX_SHARED_POSTGRES_PORT" ) \
+  $( [[ ! -z "$PRX_CASTLE_POSTGRES_HOST" ]] && printf %s "-L $CASTLE_LOCAL_PORT:$PRX_CASTLE_POSTGRES_HOST:$PRX_CASTLE_POSTGRES_PORT" ) \
+  $( [[ ! -z "$PRX_SHARED_REDIS_HOST" ]] && printf %s "-L $REDIS_LOCAL_PORT:$PRX_SHARED_REDIS_HOST:$PRX_SHARED_REDIS_PORT" ) \
+  $SSH_OPTS


### PR DESCRIPTION
Part of PRX/internal#733

- Adds `awstunnel` command
- Update `awssh` and `awstunnel` to take in an optional `--region us-west-2`
- Pull env+regional configs from jump servers
- Support for `PRX_SSH_KEY` and `PRX_AWS_PROFILE` ENVs