### PR TITLE
Add compression by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,6 @@ ruby "3.3.5"
 
 gem "standard"
 gem "rake"
+gem "racc"
+gem "base64"
+gem "ostruct"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,14 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    base64 (0.2.0)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
+    ostruct (0.6.0)
     parallel (1.22.1)
     parser (3.2.2.0)
       ast (~> 2.4.1)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.7.0)
@@ -36,10 +39,14 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES
+  base64
+  ostruct
+  racc
   rake
   standard
 

--- a/bin/awssh
+++ b/bin/awssh
@@ -1,7 +1,7 @@
 #!/bin/bash
 PRX_DEFAULT_REGION=us-east-1
 SSH_USER=ec2-user
-SSH_OPTS="-o StrictHostKeyChecking=accept-new"
+SSH_OPTS="-o StrictHostKeyChecking=accept-new -C"
 [[ ! -z $PRX_SSH_KEY ]] && SSH_OPTS="$SSH_OPTS -i $PRX_SSH_KEY"
 [[ ! -z $PRX_AWS_PROFILE ]] && export AWS_PROFILE="$PRX_AWS_PROFILE"
 

--- a/bin/awstunnel
+++ b/bin/awstunnel
@@ -1,7 +1,7 @@
 #!/bin/bash
 PRX_DEFAULT_REGION=us-east-1
 SSH_USER=ec2-user
-SSH_OPTS="-o StrictHostKeyChecking=accept-new"
+SSH_OPTS="-o StrictHostKeyChecking=accept-new -C"
 [[ ! -z $PRX_SSH_KEY ]] && SSH_OPTS="$SSH_OPTS -i $PRX_SSH_KEY"
 [[ ! -z $PRX_AWS_PROFILE ]] && export AWS_PROFILE="$PRX_AWS_PROFILE"
 


### PR DESCRIPTION
Adds compression to the ssh tunnels.

I added it mainly for the database link where it can really speed things up, but is also useful for the console/shell access via awssh.