### PR TITLE
Break out stderr and stdout handling

### DIFF
--- a/bin/awstunnel
+++ b/bin/awstunnel
@@ -26,21 +26,27 @@ fi
 echo "Connecting to $JUMP_HOST..."
 
 # get env, and check for host key failure (jump servers can cycle out)
-OUT=`ssh $SSH_USER@$JUMP_HOST $SSH_OPTS 'printenv | grep ^PRX_' 2>&1`
-if [[ $? != 0 ]]; then
-  if [[ $OUT =~ "Host key verification failed" ]]; then
+ERR=$(mktemp)
+trap 'rm -f "$ERR"' EXIT
+OUT=$(ssh $SSH_USER@$JUMP_HOST $SSH_OPTS 'printenv | grep ^PRX_' 2>"$ERR")
+STATUS=$?
+if [[ $STATUS != 0 ]]; then
+  if grep -q "Host key verification failed" "$ERR"; then
     echo "Removing stale known_hosts for $JUMP_HOST..."
     ssh-keygen -R $JUMP_HOST > /dev/null
 
     echo "Reconnecting to $JUMP_HOST..."
-    OUT=`ssh $SSH_USER@$JUMP_HOST $SSH_OPTS 'printenv | grep ^PRX_'`
-    if [[ $? != 0 ]]; then exit 1; fi
+    OUT=$(ssh $SSH_USER@$JUMP_HOST $SSH_OPTS 'printenv | grep ^PRX_' 2>"$ERR")
+    if [[ $? != 0 ]]; then cat "$ERR" >&2; exit 1; fi
   else
-    echo $OUT
+    cat "$ERR" >&2
     exit 1
   fi
 fi
-export xargs $OUT
+cat "$ERR" >&2
+while IFS= read -r LINE; do
+  [[ $LINE =~ ^PRX_[A-Za-z0-9_]*= ]] && export "$LINE"
+done <<< "$OUT"
 
 # TODO: do we care to vary local ports by env/region?
 if [[ $ENV == "prod" ]]; then


### PR DESCRIPTION
My local ssh client is giving me an error banner:

```
** WARNING: connection is not using a post-quantum key exchange algorithm.
** This session may be vulnerable to "store now, decrypt later" attacks.
** The server may need to be upgraded. See https://openssh.com/pq.html`
```

Because stdout and stderr are being mixed to test key handling, this is causing all kinds of globbing and weirdness when I execute the script. 

This PR fixes the case where the messages show up in stderr but the ssh command does not exit.

  - Captures SSH stdout and stderr separately
  - Checks SSH exit status before processing remote environment output
  - Preserves stderr handling for host-key failure recovery
  - Only exports valid PRX_...=... environment lines
  - Avoids unquoted expansion of mixed SSH output
  - Prevents SSH warning banners from being interpreted as shell/export input